### PR TITLE
Autogenerate objects at runtime

### DIFF
--- a/pkg/kubevirtobjs/virtualmachine.go
+++ b/pkg/kubevirtobjs/virtualmachine.go
@@ -260,5 +260,26 @@ func NewDefaultVirtualMachine2() *k6tv1.VirtualMachine {
 	vm := k6tv1.VirtualMachine{}
 	vm.Spec.Template = &tmpl
 	k6tv1.SetObjectDefaults_VirtualMachine(&vm)
+	// workaround for k6t
+	setObjectDefaults_VirtualMachine(&vm)
 	return &vm
+}
+
+func setObjectDefaults_VirtualMachine(in *k6tv1.VirtualMachine) {
+	if in.Spec.Template != nil {
+		for i := range in.Spec.Template.Spec.Domain.Devices.Disks {
+			a := &in.Spec.Template.Spec.Domain.Devices.Disks[i]
+			if a.DiskDevice.CDRom != nil {
+				setDefaults_CDRomTarget(a.DiskDevice.CDRom)
+			}
+		}
+	}
+}
+
+func setDefaults_CDRomTarget(obj *k6tv1.CDRomTarget) {
+	_true := true
+	obj.ReadOnly = &_true
+	if obj.Tray == "" {
+		obj.Tray = k6tv1.TrayStateClosed
+	}
 }

--- a/pkg/kubevirtobjs/virtualmachine.go
+++ b/pkg/kubevirtobjs/virtualmachine.go
@@ -145,6 +145,12 @@ func NewDomainSpec(numDisks, numIfaces, numPortsPerIface uint) (*k6tv1.DomainSpe
 		},
 		Firmware: &k6tv1.Firmware{},
 		Clock: &k6tv1.Clock{
+			ClockOffset: k6tv1.ClockOffset{
+				UTC: &k6tv1.ClockOffsetUTC{
+					OffsetSeconds: new(int),
+				},
+				Timezone: new(k6tv1.ClockOffsetTimezone),
+			},
 			Timer: &k6tv1.Timer{
 				HPET:   &k6tv1.HPETTimer{Enabled: &enabled},
 				KVM:    &k6tv1.KVMTimer{Enabled: &enabled},

--- a/pkg/kubevirtobjs/virtualmachine_test.go
+++ b/pkg/kubevirtobjs/virtualmachine_test.go
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ */
+
+package kubevirtobjs
+
+import (
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestAutogen(t *testing.T) {
+	obj1 := NewDefaultVirtualMachine()
+	obj2 := NewDefaultVirtualMachine2()
+	// both are equally "right", just pick your favorite
+	obj2.Spec.Template.Spec.Domain.Firmware.UUID = obj1.Spec.Template.Spec.Domain.Firmware.UUID
+	ok := reflect.DeepEqual(obj1, obj2)
+	if !ok {
+		cs := spew.NewDefaultConfig()
+		cs.DisablePointerAddresses = true
+		cs.DisableCapacities = true
+		cs.SortKeys = true
+		ioutil.WriteFile("obj1.dump", []byte(cs.Sdump(obj1)), 0644)
+		ioutil.WriteFile("obj2.dump", []byte(cs.Sdump(obj2)), 0644)
+		t.Errorf("objects not equal")
+	}
+}


### PR DESCRIPTION
With this PR, the code can now autogenerate fully-populated objects.
We will need anyway to recompile when the kubevirt API schema changes, but at least we will not need anymore to create objects manually.
Closes https://github.com/fromanirh/kubevirt-template-validator/issues/3