### PR TITLE
functests: add sleep after template submission

### DIFF
--- a/functests/03-test-with-template-with-rules-satisfied.sh
+++ b/functests/03-test-with-template-with-rules-satisfied.sh
@@ -2,6 +2,7 @@
 {
 RET=1
 $KUBECTL create -n default -f manifests/template-with-rules.yaml || exit 2
+sleep 1s
 $KUBECTL create -f manifests/03-vm-from-template-with-rules-satisfied.yaml
 if $KUBECTL get vm vm-test-03; then
 	RET=0

--- a/functests/04-test-with-template-with-rules-unfulfilled.sh
+++ b/functests/04-test-with-template-with-rules-unfulfilled.sh
@@ -2,6 +2,7 @@
 {
 RET=0
 $KUBECTL create -n default -f manifests/template-with-rules.yaml || exit 2
+sleep 1s
 if $KUBECTL create -f manifests/04-vm-from-template-with-rules-unfulfilled.yaml ; then
 	RET=1
 	$KUBECTL delete vm vm-test-04

--- a/functests/05-test-with-template-with-optional-rules-unfulfilled.sh
+++ b/functests/05-test-with-template-with-optional-rules-unfulfilled.sh
@@ -2,6 +2,7 @@
 {
 RET=1
 $KUBECTL create -n default -f manifests/template-with-rules-optional.yaml || exit 2
+sleep 1s
 $KUBECTL create -f manifests/05-vm-from-template-with-optional-rules-unfulfilled.yaml
 if $KUBECTL get vm vm-test-05; then
 	RET=0

--- a/functests/06-test-with-template-with-rules-for-unspecified-path.sh
+++ b/functests/06-test-with-template-with-rules-for-unspecified-path.sh
@@ -2,6 +2,7 @@
 {
 RET=0
 $KUBECTL create -n default -f manifests/template-with-rules.yaml  || exit 2
+sleep 1s
 # will fail because the default value if not specified is the zero value, so this VM will have zero cores (!)
 if $KUBECTL create -f manifests/06-vm-from-template-with-rules-and-unspecified-paths.yaml; then
 	RET=1

--- a/functests/07-test-with-template-with-incorrect-rules-satisfied.sh
+++ b/functests/07-test-with-template-with-incorrect-rules-satisfied.sh
@@ -2,6 +2,7 @@
 {
 RET=0
 $KUBECTL create -n default -f manifests/template-with-rules-incorrect.yaml  || exit 2
+sleep 1s
 if $KUBECTL create -f manifests/07-vm-from-template-with-incorrect-rules-satisfied.yaml ;  then
 	RET=1
 	$KUBECTL delete vm vm-test-07

--- a/functests/08-test-with-template-with-incorrect-rules-unfulfilled.sh
+++ b/functests/08-test-with-template-with-incorrect-rules-unfulfilled.sh
@@ -2,6 +2,7 @@
 {
 RET=0
 $KUBECTL create -n default -f manifests/template-with-rules-incorrect.yaml  || exit 2
+sleep 1s
 if $KUBECTL create -f manifests/08-vm-from-template-with-incorrect-rules-unfulfilled.yaml ; then
 	RET=1
 	$KUBECTL delete vm vm-test-08


### PR DESCRIPTION
reduce false negative when the test host is too slow

Signed-off-by: Francesco Romani <fromani@redhat.com>