### PR TITLE
test-runner.sh: env vars should be optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
   include:
   - stage: Tests
     name: "minishift"
-    env: CPLATFORM=minishift TARGET=functests KUBECTL=oc OC=oc V=5 CI_CONFIG_FEATURE_GATES=DataVolumes,LiveMigration,CPUManager CI_CONFIG_ADMISSION_WEBHOOK=1
+    env: CPLATFORM=minishift TARGET=functests V=5 CI_CONFIG_FEATURE_GATES=DataVolumes,LiveMigration,CPUManager CI_CONFIG_ADMISSION_WEBHOOK=1
 
   - stage: Build and Deploy
     name: Build and Deploy to GitHub

--- a/functests/test-runner.sh
+++ b/functests/test-runner.sh
@@ -11,6 +11,9 @@ if [ -z "${KUBECTL}" ]; then
 	KUBECTL="${OC}"
 fi
 
+export OC
+export KUBECTL
+
 MISSING=0
 #for EXE in jq; do
 #	if [ ! which -- ${EXE} &> /dev/null ]; then

--- a/functests/test-runner.sh
+++ b/functests/test-runner.sh
@@ -5,12 +5,10 @@ fi
 
 # checking prereqs
 if [ -z "${OC}" ]; then
-	echo "please define the environment variable 'OC'"
-	exit 2
+	OC=oc
 fi
 if [ -z "${KUBECTL}" ]; then
-	echo "please define the environment variable 'KUBECTL'"
-	exit 2
+	KUBECTL="${OC}"
 fi
 
 MISSING=0


### PR DESCRIPTION
The original intent of OC and KUBECTL was to make it possible
to use custom binaries, not to require them.
This patch sets sane defaults for both variables, making them
actually optional.

Signed-off-by: Francesco Romani <fromani@redhat.com>