### PR TITLE
backward/forward compatibility functest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,5 @@ before_script:
 
 script:
 - bash -x test.sh
-- bash -x hack/env/upgrade-kubevirt.sh v0.19.0
-- bash -x hack/env/wait-kubevirt.sh
-- bash -x test.sh
+- bash -x hack/env/upgrade-and-test.sh v0.19.0
+- bash -x hack/env/upgrade-and-test.sh latest v0.19.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,13 @@ before_script:
 - bash -x ci/prepare-host $CPLATFORM
 - bash -x ci/prepare-host virtctl
 - bash -x ci/start-cluster $CPLATFORM $CVER
-- bash -x ci/deploy-kubevirt $CPLATFORM
+- bash -x ci/deploy-kubevirt $CPLATFORM v0.18.1
 
 - bash -x hack/env/build-validator.sh
 - bash -x hack/env/install-validator.sh
 
 script:
+- bash -x test.sh
+- bash -x hack/env/upgrade-kubevirt.sh v0.19.0
+- bash -x hack/env/wait-kubevirt.sh
 - bash -x test.sh

--- a/hack/ci/stop-cluster
+++ b/hack/ci/stop-cluster
@@ -1,0 +1,20 @@
+#!/bin/bash
+# usage: stop-cluster (minikube|oc_cluster) $CLUSTER_VERSION
+
+set -e
+
+source $(dirname $(realpath $0))/../../ci/ci/defaults
+
+warn() { echo "WARN: $@" >&2 ; }
+condarg() { [[ -n "$2" ]] && echo "$1$2"; }
+
+_minishift() {
+  local CVER=$1
+
+  minishift stop
+  minishift delete -f
+}
+
+_${1:-$DEFAULT_PLATFORM} ${2:-$DEFAULT_CLUSTER_VERSION}
+
+sleep 5

--- a/hack/env/latest-versions.py
+++ b/hack/env/latest-versions.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import collections
+import sys
+import json
+
+
+_version = collections.namedtuple('_version', ['major', 'minor', 'micro'])
+
+
+class Version(_version):
+
+    @classmethod
+    def from_string(cls, text):
+        text = text.lstrip("v")
+        text = text.split("-")[0]  # TODO: handle '-extra'?
+        major, minor, micro = text.split('.')
+        return cls(int(major), int(minor), int(micro))
+
+    def __str__(self):
+        return "v%d.%d.%d" % (self.major, self.minor, self.micro)
+
+
+def versions(data):
+    versions = [ Version.from_string(item['tag_name']) for item in data]
+    buckets = {}
+    for ver in versions:
+        key = (ver.major, ver.minor)
+        if key not in buckets:
+            buckets[key] = ver
+        else:
+            cur = buckets[key]
+            buckets[key] = ver if ver > cur else cur
+    return list(reversed(sorted(buckets.values())))
+
+
+if __name__ == "__main__":
+    vers = versions(json.load(sys.stdin))
+    print(str(vers[0]))

--- a/hack/env/try-login.sh
+++ b/hack/env/try-login.sh
@@ -3,7 +3,7 @@
 OC=oc
 
 while true; do
-	oc login -u system:admin && exit 0
+	oc login -u system:admin -p '' && exit 0
 	echo "waiting to login into cluster..."
 	sleep 2
 done

--- a/hack/env/upgrade-and-test.sh
+++ b/hack/env/upgrade-and-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+SELF=$( realpath $0 )
+BASEPATH=$( dirname $SELF )
+
+TARGET_VERSION="${1}"
+CURRENT_VERSION="${2}"
+if [ "$1" == "latest" ]; then
+	TARGET_VERSION=$( curl --silent -k "https://api.github.com/repos/kubevirt/kubevirt/releases" |  ${BASEPATH}/latest-versions.py )
+fi
+
+if [ "${TARGET_VERSION}" == "${CURRENT_VERSION}" ]; then
+	echo "nothing to do: target == current"
+	exit 0
+fi
+
+bash -x ${BASEPATH}/upgrade-kubevirt.sh ${TARGET_VERSION}
+bash -x ${BASEPATH}/wait-kubevirt.sh
+# -e is important to let make use the vars defined in "matrix:" above
+make -e $TARGET

--- a/hack/env/upgrade-kubevirt.sh
+++ b/hack/env/upgrade-kubevirt.sh
@@ -6,6 +6,11 @@ BASEPATH=$( dirname $SELF )
 
 # we can't guess.
 [ -z "$1" ] && exit 1
+RELEASE="${1}"
 
-oc patch kv kubevirt -n kubevirt --type=json -p "[{ \"op\": \"add\", \"path\": \"/spec/imageTag\", \"value\": \"$1\" }]"
+# avoids https://github.com/kubevirt/kubevirt/issues/2533
+oc apply -f https://github.com/kubevirt/kubevirt/releases/download/${RELEASE}/kubevirt-operator.yaml
+# TODO: smarter wait
+sleep 42s
+oc patch kv kubevirt -n kubevirt --type=json -p "[{ \"op\": \"add\", \"path\": \"/spec/imageTag\", \"value\": \"${RELEASE}\" }]"
 

--- a/hack/env/upgrade-kubevirt.sh
+++ b/hack/env/upgrade-kubevirt.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+SELF=$( realpath $0 )
+BASEPATH=$( dirname $SELF )
+
+# we can't guess.
+[ -z "$1" ] && exit 1
+
+oc patch kv kubevirt -n kubevirt --type=json -p "[{ \"op\": \"add\", \"path\": \"/spec/imageTag\", \"value\": \"$1\" }]"
+

--- a/hack/env/wait-kubevirt.sh
+++ b/hack/env/wait-kubevirt.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ex
+
+SELF=$( realpath $0 )
+BASEPATH=$( dirname $SELF )
+
+(
+  kubectl wait --timeout=240s --for=condition=Ready -n kubevirt kv/kubevirt ;
+) || {
+  echo "Something went wrong"
+  kubectl describe -n kubevirt kv/kubevirt
+  kubectl describe pods -n kubevirt
+  exit 1
+}
+
+# Give kvm some time to be announced
+sleep 12
+
+kubectl describe nodes

--- a/hack/tests/setup.sh
+++ b/hack/tests/setup.sh
@@ -6,7 +6,7 @@ BASEPATH=$( dirname $SELF )
 ENVPATH="${BASEPATH}/../env"
 
 ${ENVPATH}/minishift/setup.sh
-sleep 40s
+sleep 50s
 
 ${ENVPATH}/try-login.sh
 sleep 10s

--- a/pkg/template-validator/app.go
+++ b/pkg/template-validator/app.go
@@ -19,11 +19,14 @@
 package validator
 
 import (
+	"fmt"
 	"net/http"
 
 	flag "github.com/spf13/pflag"
 
 	"k8s.io/client-go/tools/cache"
+
+	k6tversion "kubevirt.io/client-go/version"
 
 	_ "github.com/fromanirh/okdutil/okd"
 
@@ -64,8 +67,14 @@ func (app *App) AddFlags() {
 	flag.BoolVarP(&app.skipInformers, "skip-informers", "S", false, "don't initialize informerers - use this only in devel mode")
 }
 
+func (app *App) KubevirtVersion() string {
+	info := k6tversion.Get()
+	return fmt.Sprintf("%s %s %s", info.GitVersion, info.GitCommit, info.BuildDate)
+}
+
 func (app *App) Run() {
 	log.Log.Infof("%s %s (revision: %s) starting", version.COMPONENT, version.VERSION, version.REVISION)
+	log.Log.Infof("%s using kubevirt client-go (%s)", version.COMPONENT, app.KubevirtVersion())
 	if app.versionOnly {
 		return
 	}


### PR DESCRIPTION
Implement backward and forward compabile functional tests. We want to test that `kubevirt-template-validator` works nicely with kubevirts whose version is older and newer than the version of client-go built-in in the server.

To do so, we intentionally deploy a version of kubevirt older than the one we have client-go for.
Then we update to the same version, and we run the tests again
Then we update to the newer version, and we run the tests again.

The alternative would be to build three different minishift setups with the aformentioned kubevirt versions. That would be cleaner, but we will have a very high risk to have false negative tests because of github API throttling - this actually happened testing an earlier PR.