### PR TITLE
Kubeobjs unittests

### DIFF
--- a/pkg/kubevirtobjs/kubevirtobjs_suite_test.go
+++ b/pkg/kubevirtobjs/kubevirtobjs_suite_test.go
@@ -1,0 +1,13 @@
+package kubevirtobjs_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestKubevirtobjs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kubevirtobjs Suite")
+}

--- a/pkg/kubevirtobjs/virtualmachine.go
+++ b/pkg/kubevirtobjs/virtualmachine.go
@@ -19,7 +19,6 @@
 package kubevirtobjs
 
 import (
-	"fmt"
 	"reflect"
 
 	k6tv1 "kubevirt.io/client-go/api/v1"
@@ -31,12 +30,6 @@ const (
 	MaxPortsPerIface uint = 16
 	MaxNTPServers    uint = 8
 	MaxItems         int  = 64
-)
-
-var (
-	ErrTooManyDisks         error = fmt.Errorf("Too many disks requested, max = %d", MaxDisks)
-	ErrTooManyIfaces        error = fmt.Errorf("Too many network interface requested, max = %d", MaxIfaces)
-	ErrTooManyPortsPerIface error = fmt.Errorf("Too many ports per network interface requested, max = %d", MaxPortsPerIface)
 )
 
 // NewVirtualMachine returns a fully zero-value VirtualMachine with all optional fields

--- a/pkg/kubevirtobjs/virtualmachine_test.go
+++ b/pkg/kubevirtobjs/virtualmachine_test.go
@@ -1,0 +1,50 @@
+package kubevirtobjs_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/fromanirh/kubevirt-template-validator/pkg/kubevirtobjs"
+
+	k6tv1 "kubevirt.io/client-go/api/v1"
+)
+
+var _ = Describe("Virtualmachine", func() {
+	var (
+		vm *k6tv1.VirtualMachine
+	)
+
+	BeforeEach(func() {
+		vm = kubevirtobjs.NewDefaultVirtualMachine()
+	})
+
+	Context("Sanity checks", func() {
+		It("Should create objects", func() {
+			Expect(vm).NotTo(BeNil())
+		})
+
+		It("Should create objects with domain", func() {
+			Expect(vm.Spec.Template.Spec.Domain).NotTo(BeNil())
+		})
+
+	})
+
+	Context("Check field access", func() {
+		It("Should NOT have defaults set outside DomainSpec", func() {
+			Expect(vm.Spec.Template.Spec.EvictionStrategy).To(BeNil())
+		})
+
+		It("Should have CPU", func() {
+			Expect(vm.Spec.Template.Spec.Domain.CPU.Cores).To(Equal(uint32(0)))
+			Expect(vm.Spec.Template.Spec.Domain.CPU.Sockets).To(Equal(uint32(0)))
+			Expect(vm.Spec.Template.Spec.Domain.CPU.Threads).To(Equal(uint32(0)))
+		})
+
+		It("Should have guest memory", func() {
+			Expect(vm.Spec.Template.Spec.Domain.Memory.Guest.IsZero()).To(BeTrue())
+		})
+		It("Should have hugepages", func() {
+			Expect(vm.Spec.Template.Spec.Domain.Memory.Hugepages.PageSize).To(Equal(""))
+		})
+	})
+})


### PR DESCRIPTION
start unittests for the kubevirtobjs package.
Only the very basics tests so far: we should find a way to autogenerate them in a comprehensive way.