### PR TITLE
Increase number of validator replicas to 2.

### DIFF
--- a/cluster/k8s/manifests/service.yaml
+++ b/cluster/k8s/manifests/service.yaml
@@ -46,7 +46,7 @@ metadata:
   labels:
     name: virtualmachine-template-validator
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       name: virtualmachine-template-validator 

--- a/cluster/okd/manifests/service.yaml
+++ b/cluster/okd/manifests/service.yaml
@@ -48,7 +48,7 @@ metadata:
   labels:
     name: virt-template-validator
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       name: virt-template-validator

--- a/functests/09-test-with-template-with-incorrect-rules-unfulfilled-just-warning.sh
+++ b/functests/09-test-with-template-with-incorrect-rules-unfulfilled-just-warning.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 {
-RET=0
+RET=1
 $KUBECTL apply -n default -f manifests/template-with-rules-incorrect-just-warning.yaml  || exit 2
 sleep 1s
 if $KUBECTL apply -f manifests/09-vm-from-template-with-incorrect-rules-just-warning.yaml ; then
-	if [ $($KUBECTL logs -n kubevirt $($KUBECTL get pods --all-namespaces | grep virt-template-validator | awk -F ' ' '{print $2}') | grep "warning.*Memory size not within range:"| wc -l) -eq 0 ]; then
-		RET=1
-	fi
-
+		while read -r pod ; do
+			#$KUBECTL logs -n kubevirt $pod
+			if [ $($KUBECTL logs -n kubevirt $pod | grep "warning.*Memory size not within range:"| wc -l) -gt 0 ]; then
+				RET=0
+			fi
+		done <<< "$($KUBECTL get pods --all-namespaces | grep virt-template-validator | awk -F ' ' '{print $2}')"
 	$KUBECTL delete vm vm-test-09
 fi
+
 $KUBECTL delete -n default -f manifests/template-with-rules-incorrect-just-warning.yaml
 exit $RET
 }


### PR DESCRIPTION
Kubevirt is using the same number of replicas for e.g. virt-controller.
Signed-off-by: ksimon1 <ksimon@redhat.com>