### PR TITLE
webhook: remove superflous call

### DIFF
--- a/pkg/webhooks/validating/hook.go
+++ b/pkg/webhooks/validating/hook.go
@@ -102,5 +102,4 @@ func serve(resp http.ResponseWriter, req *http.Request, admit admitFunc) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	resp.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Get rid of the warning
```
http: superfluous response.WriteHeader call from github.com/fromanirh/kubevirt-template-validator/pkg/webhooks/validating.serve (hook.go:105)
```

Signed-off-by: Francesco Romani <fromani@redhat.com>